### PR TITLE
Generate assets for UV download

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The easiest way to run the script is via Docker. This will ensure all dependenci
 2x volume mounts are required for running the script:
 
 - `/path/to/images/` - this is a local folder containing the manuscript images to be processed. These relate to rows in spreadsheet and must be in format `"{NO}. {MHS_NUMBER}"` (e.g. "1. MLE-ARC-MS3", "2. MLE-ARC-MS4").
-- `/path/for/output` - this is where all generated manifests and image tiles will be output to. The final output will generate `/iamges/api` and `/manifest` folders underneath here.
+- `/path/for/output/` - this is where all generated manifests and image tiles will be output to. The final output will generate `/iamges/api` and `/manifest` folders underneath here.
 
 To run via Docker:
 

--- a/app/image_processor.py
+++ b/app/image_processor.py
@@ -104,15 +104,15 @@ class ImageProcessor:
 
             # Set image height and width, and canvas to same dimensions
             image_file = manuscript_images[p]
-            self._generate_image_pyramid(image_file, image_id)
             img.set_hw_from_file(image_file)
             cvs.height = img.height
             cvs.width = img.width
+            self._generate_image_pyramid(image_file, image_id, img.width, img.height)
 
             end = time.time()
             print(f"processed {image_id} in {end - start} secs")
 
-    def _generate_image_pyramid(self, image_file: str, image_id: str) -> None:
+    def _generate_image_pyramid(self, image_file: str, image_id: str, width: int, height: int) -> None:
         if not self._generate_images:
             return
 
@@ -120,3 +120,10 @@ class ImageProcessor:
 
         # generate a 90-wide thumb for UV (see: https://github.com/UniversalViewer/universalviewer/issues/102)
         self._tile_generator.generate_tile("full", [90, None])
+
+        # generate a 1000-wide /full/ image for UV download
+        h = 1000 / (width / height)
+        self._tile_generator.generate_tile("full", [1000, h])
+
+        # generate a max-width /full/ image for UV download
+        self._tile_generator.generate_tile("full", [width, None])


### PR DESCRIPTION
UV looks for 1000-wide and max-width (as specified by info.json)
resources to be in /full/ for download